### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,28 +1,33 @@
 {
   "name": "noflo-xml",
   "description": "XML components for the NoFlo flow-based programming environment",
-  "keywords": ["noflo", "xml"],
+  "keywords": [
+    "noflo",
+    "xml"
+  ],
   "author": "Henri Bergius <henri.bergius@iki.fi>",
   "version": "0.0.3",
-  "licenses": [{
-    "type": "MIT",
-    "url": "https://github.com/bergie/noflo/raw/master/LICENSE"
-  }],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/bergie/noflo/raw/master/LICENSE"
+    }
+  ],
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/noflo/noflo-xml.git"
+    "type": "git",
+    "url": "https://github.com/noflo/noflo-xml.git"
   },
   "engines": {
     "node": ">=0.6.0"
   },
   "dependencies": {
-    "noflo": "0.5.x",
-    "xml2js": "0.2.x"
+    "noflo": "0.5.13",
+    "xml2js": "0.2.8"
   },
   "devDependencies": {
-    "nodeunit": ">=0.6.0",
-    "coffeelint": "*",
-    "coffee-script": "1.4.x"
+    "nodeunit": "0.9.1",
+    "coffeelint": "1.12.1",
+    "coffee-script": "1.4.0"
   },
   "noflo": {
     "components": {


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:

- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>